### PR TITLE
Dont run script without gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ clamd backend.
 A container image is available at
 [dockerhub](https://hub.docker.com/r/temal/clamav-rest).
 
-## Developing locally (with docker)
+## Development
 
 Requirements:
 
+- python3
+- pipenv
 - docker
+
+### Starting service via docker
 
 Run the following to get up and running:
 
@@ -47,22 +51,30 @@ Run the following to get up and running:
 docker-compose up -d
 ```
 
+### Rebuild container after change
+
 After changing code, run the following command to renew the clamav-rest container:
 
 ```
 docker-compose up -d --remove-orphans --build clamav_rest
 ```
 
-## Developing locally (without docker)
+### Run tests locally
 
-Requirements:
-
-- python3
-- pipenv
-
-Run the following to get up and running:
+To run the tests, do the following:
 
 ```
 pipenv shell
 pipenv install
+python clamav_rest_test.py
 ```
+
+## Environment variables
+
+| Environment variable | Required | Default | Purpose |
+| -------------------- | -------- | ------- | ------- |
+| LOGLEVEL             | false    | INFO    | Loglevel |
+| CLAMD_HOST           | false    | clamav  | Hostname where to reach clamav container |
+| CLAMD_PORT           | false    | 3310    | Port where to reach clamav container |
+| LISTEN_HOST          | false    | 0.0.0.0 | IP to listen on inside container |
+| LISTEN_PORT          | false    | 8080    | Port to listen on inside container |

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -76,7 +76,3 @@ def health_ready():
     except BaseException as e:
         logger.error(e)
         return 'Service Unavailable', 500
-
-
-if __name__ == '__main__':
-    app.run(host=app.config['LISTEN_HOST'], port=app.config['LISTEN_PORT'])

--- a/config.py
+++ b/config.py
@@ -3,5 +3,3 @@ import os
 LOGLEVEL = os.environ.get('LOGLEVEL', 'INFO')
 CLAMD_HOST = os.environ.get('CLAMD_HOST', 'localhost')
 CLAMD_PORT = int(os.environ.get('CLAMD_PORT', 3310))
-LISTEN_HOST = os.environ.get('HOST', '0.0.0.0')
-LISTEN_PORT = int(os.environ.get('PORT', 8080))

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-gunicorn -w 1 -b 0.0.0.0:$PORT --timeout 1000 clamav_rest:app
+gunicorn -w 1 -b ${LISTEN_HOST:-0.0.0.0}:${LISTEN_PORT:-8080} --timeout 1000 clamav_rest:app


### PR DESCRIPTION
The whole purpose of this tool is to run in docker/kubernetes, so we disable the ability to run it locally (for now).