### PR TITLE
Run multiple worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ EXPOSE $PORT
 
 COPY --from=build-image /app /app/
 
-CMD ["/app/bin/hypercorn", "-b", "0.0.0.0:8080", "clamav_rest:app"]
+CMD ["/app/bin/hypercorn", "-b", "0.0.0.0:8080", "-w", "2", "clamav_rest:app"]

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -34,9 +34,9 @@ def auth_required(func):
             auth = request.authorization
             if (
                 auth is not None and
-                auth.type == "basic" and
-                auth.username == current_app.config["AUTH_USERNAME"] and
-                compare_digest(auth.password, current_app.config["AUTH_PASSWORD"])
+                auth.type == 'basic' and
+                auth.username == current_app.config['AUTH_USERNAME'] and
+                compare_digest(auth.password, current_app.config['AUTH_PASSWORD'])
             ):
                 return await func(*args, **kwargs)
             else:


### PR DESCRIPTION
Run two instead of one worker. In the near future this should be configurable instead of being hardcoded in the container.